### PR TITLE
Fix some issues when running build.sh today(05052015)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ if [ ! -d NDK ]; then
 fi
 
 TODAY=$(date -ju "+%Y-%m-%d")
-URL="http://static.rust-lang.org/dist/$TODAY/rustc-nightly-src.tar.gz"
+URL="http://static.rust-lang.org/dist/rustc-nightly-src.tar.gz"
 
 printf '\e[32;1mDownloading rustc nightly...\e[0m ('$URL')\n'
 
@@ -63,9 +63,7 @@ if [ ! -f config.mk ]; then
             --disable-llvm-assertions \
             --enable-fast-make \
             --enable-ccache \
-            --enable-nightly \
             --android-cross-path="$ROOT/NDK" \
-            --disable-verify-install \
             --disable-jemalloc \
             --enable-clang
 fi
@@ -79,10 +77,11 @@ cd ../cargo
         --disable-cross-tests \
         --local-rust-root="$ROOT/build/x86_64-apple-darwin/stage2/"
 make
-cp ./target/x86_64-apple-darwin/cargo ../build/x86_64-apple-darwin/stage2/bin
+cp ./target/x86_64-apple-darwin/debug/cargo ../build/x86_64-apple-darwin/stage2/bin
 
 printf '\e[32;1mPackaging...\e[0m\n'
 
+cd ..
 tar cfJ "rust-ios-android-${TODAY}.tar.xz" build/x86_64-apple-darwin/stage2
 
 printf '\e[32;1mDone.\e[0m\n'


### PR DESCRIPTION
1. The daily build directory is not always sync to the time, i.e, you run the script before they create the daily folder. So I change the URL to use the latest nightly src from http://static.rust-lang.org/dist/rustc-nightly-src.tar.gz
2. The configure options(--enalble-nightly --disable-verify-install) for the latest nightly src are missing
3. The cargo output is now at ./target/x86_64-apple-darwin/debug/cargo

Please check and review.

Br,
Nick
