### PR TITLE
Update minimum Rust version to 1.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ osx_image: xcode9.2
 
 jobs:
   include:
-    - rust: 1.19.0
+    - rust: 1.20.0
       os: linux
     - rust: 1.24.1
       os: linux

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ rust-ios-android
 Example project for building a library for iOS + Android in Rust. macOS is
 required for iOS development.
 
-* ✓ Rust 1.19 – 1.25
+* ✓ Rust 1.20 – 1.25
 * ✓ Android 4.1 – 8.1 (Jelly Bean – Oreo) (API 16–27)
 * ✓ iOS 7 – 11
 


### PR DESCRIPTION
Build fails because it requires associated constants, which are only available on 1.20 or newer.