### PR TITLE
Update the Android build

### DIFF
--- a/create-ndk-standalone.sh
+++ b/create-ndk-standalone.sh
@@ -37,8 +37,8 @@ create_ndk() {
 }
 
 create_ndk arm64 21
-create_ndk arm 14
-create_ndk x86 14
+create_ndk arm 16
+create_ndk x86 16
 
 echo 'Updating cargo-config.toml...'
 

--- a/sample/android/build.gradle
+++ b/sample/android/build.gradle
@@ -1,27 +1,28 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha13'
     }
 }
 
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.0'
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId 'kennytm.rustsample'
-        minSdkVersion 15
-        targetSdkVersion 27
+        minSdkVersion 16
+        targetSdkVersion 28
         versionCode 2
         versionName '0.1.1'
     }
 }
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.2.1'
+repositories {
+    google()
+    jcenter()
 }

--- a/sample/android/gradle/wrapper/gradle-wrapper.properties
+++ b/sample/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Oct 08 09:14:06 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
Updates the android build in response to issue https://github.com/kennytm/rust-ios-android/issues/12 by changing the minimum version to 16 instead of 14 for arm and x86. 

Also includes updates to the build file to use google's maven repositories and other minor cleanups that should simplify the gradle file a bit.